### PR TITLE
Add GPG key link alongside email contact

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -56,6 +56,17 @@
             fill: #f4d03f;
             vertical-align: middle;
         }
+        .icon-link {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+        }
+        .icon-link .icon-label {
+            font-size: 1.1rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
         .banner {
             font-size: 1.5rem;
             margin-bottom: 20px;

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: Sunmeet's Zero Point
         <p>Hi! I'm a sentient being exploring the vastness of the cosmos, much like Arthur Dent. Feel free to reach out if you'd like to chat about life, the universe, and everything.</p>
         <a href="https://www.linkedin.com/in/sunmeetsingh/" target="_blank">LinkedIn</a>
         <a href="https://www.instagram.com/_sun_meet_/" target="_blank">Instagram</a>
-        <a href="mailto:me@sunmeet.ca" target="_blank">
+        <a class="icon-link" href="mailto:me@sunmeet.ca" target="_blank" aria-label="Email Sunmeet">
             <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 75.294 75.294">
                 <path d="M66.097,12.089h-56.9C4.126,12.089,0,16.215,0,21.286v32.722c0,5.071,4.126,9.197,9.197,9.197h56.9
                 c5.071,0,9.197-4.126,9.197-9.197V21.287C75.295,16.215,71.169,12.089,66.097,12.089z M61.603,18.089L37.647,33.523L13.691,18.089
@@ -19,5 +19,12 @@ title: Sunmeet's Zero Point
                 c0.025-0.006,0.05-0.009,0.075-0.016c0.243-0.063,0.48-0.159,0.712-0.278c0.044-0.022,0.088-0.045,0.131-0.069
                 c0.041-0.023,0.084-0.04,0.124-0.065l29.796-19.16v32.551C69.295,55.771,67.86,57.206,66.097,57.206z"/>
             </svg>
+            <span class="icon-label">Email</span>
         </a>
-    </div>
+        <a class="icon-link" href="https://keys.openpgp.org/vks/v1/by-fingerprint/3D122F7985960CB02072ED55072797E63ED6CC8E" target="_blank" rel="noopener noreferrer" aria-label="View Sunmeet's GPG key">
+            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+                <path d="M40 6a18 18 0 0 0-16.04 26.84L5.293 51.5A1 1 0 0 0 5 52.207V62a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-5h5a1 1 0 0 0 1-1v-5h5a1 1 0 0 0 .707-.293l5.117-5.117 3.129 3.13A18 18 0 1 0 40 6zm0 34a16 16 0 1 1 16-16 16.018 16.018 0 0 1-16 16zM14 61H7v-8.586l18.707-18.707 6.586 6.586L28.586 44A1 1 0 0 0 28 45v5h-5a1 1 0 0 0-1 1v5h-5a1 1 0 0 0-1 1zm26-41a7 7 0 1 0 7 7 7.008 7.008 0 0 0-7-7zm0 12a5 5 0 1 1 5-5 5.006 5.006 0 0 1-5 5z"/>
+            </svg>
+            <span class="icon-label">GPG Key</span>
+        </a>
+</div>


### PR DESCRIPTION
## Summary
- add a dedicated icon link for contacting via email and include a new GPG key link on the landing page
- style icon-based links to align with the existing theme and spacing

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68ecb6da436c8331b0f5b965bfb968c6